### PR TITLE
Feat/#6 초기세팅 및 카카오 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "monyam",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.6.8",
         "eslint-config-prettier": "^9.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -15,6 +16,7 @@
         "styled-components": "^6.1.8"
       },
       "devDependencies": {
+        "@types/node": "^20.12.7",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@types/styled-components": "^5.1.34",
@@ -1015,6 +1017,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
@@ -1339,6 +1350,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1412,6 +1438,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1474,6 +1511,14 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1840,6 +1885,38 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2166,6 +2243,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -2376,6 +2472,11 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2779,6 +2880,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.6.8",
     "eslint-config-prettier": "^9.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -17,6 +18,7 @@
     "styled-components": "^6.1.8"
   },
   "devDependencies": {
+    "@types/node": "^20.12.7",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@types/styled-components": "^5.1.34",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Outer from './pages/Outer'
 import Landing from './pages/Landing'
+import Login from './pages/Login'
 
 const Router = () => {
   return (
@@ -8,6 +9,7 @@ const Router = () => {
       <Routes>
         <Route path="/" element={<Outer />}>
           <Route path="" element={<Landing />} />
+          <Route path="login" element={<Login />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Outer from './pages/Outer'
 import Landing from './pages/Landing'
 import Login from './pages/Login'
+import KakaoRedirection from './pages/KakaoRedirection'
 
 const Router = () => {
   return (
@@ -10,6 +11,7 @@ const Router = () => {
         <Route path="/" element={<Outer />}>
           <Route path="" element={<Landing />} />
           <Route path="login" element={<Login />} />
+          <Route path="auth" element={<KakaoRedirection />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/apis/UserApi.tsx
+++ b/src/apis/UserApi.tsx
@@ -1,0 +1,20 @@
+import axios from 'axios'
+
+const serverUrl = import.meta.env.VITE_SERVER_URL
+const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI
+
+// 인가코드를 통해 카카오에 등록된 유저정보 받기
+export const getKakaoUserInfoApi = (code: string) => {
+  return axios.get(`http://${serverUrl}/oauth/kakao/callback?code=${code}&redirectUri=${redirectUri}`)
+}
+
+// 카카오 어세스토큰을 통하여 jwt토큰 받기
+export const loginApi = (accessToken: string, nickname: string) => {
+  return axios.post(
+    `http://${serverUrl}/api/oauth/login`,
+    { memberType: 'KAKAO', nickname: nickname },
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+}

--- a/src/assets/kakaoRedirection/Loading.svg
+++ b/src/assets/kakaoRedirection/Loading.svg
@@ -1,0 +1,15 @@
+<svg width="105" height="105" viewBox="0 0 105 105" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H104.286V104.286H0V0Z" fill="white" fill-opacity="0.01"/>
+<path d="M52.1431 8.69054V17.3811" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M73.8697 14.512L69.5244 22.0381" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M89.7743 30.4169L82.248 34.7621" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M95.5958 52.1432H86.9053" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M89.7743 73.8696L82.248 69.5243" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M73.8697 89.7745L69.5244 82.2483" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M52.1431 95.5959V86.9054" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30.417 89.7745L34.7623 82.2483" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.5112 73.8696L22.0374 69.5243" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.69043 52.1432H17.381" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.5112 30.4169L22.0374 34.7621" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30.417 14.512L34.7623 22.0381" stroke="black" stroke-width="8.69054" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App.tsx'
 import './main.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <App />,
+  // </React.StrictMode>,
 )

--- a/src/pages/KakaoRedirection.tsx
+++ b/src/pages/KakaoRedirection.tsx
@@ -1,0 +1,98 @@
+import styled from 'styled-components'
+import { useNavigate } from 'react-router-dom'
+import { useEffect } from 'react'
+import { getKakaoUserInfoApi, loginApi } from '../apis/UserApi'
+import loading from '../assets/kakaoRedirection/Loading.svg'
+
+const KakaoRedirection = () => {
+  //카카오 인가코드
+  const code = new URL(document.location.toString()).searchParams.get('code')
+  const navigate = useNavigate()
+
+  // GetKakaoUserInfo함수의 response 인터페이스
+  interface KakaoUserInfoResponseProps {
+    data: any
+    status: number
+    statusText: string
+    headers: any
+    config: any
+  }
+
+  // Login함수의 response 인터페이스
+  interface LoginProps {
+    data: any
+    status: number
+    statusText: string
+    headers: any
+    config: any
+  }
+
+  // 카카오에서 유저정보 받아오기
+  const getKakaoUserInfo = async (code: string) => {
+    try {
+      await getKakaoUserInfoApi(code).then((res: KakaoUserInfoResponseProps) => {
+        if (res.status === 200) {
+          login(res.data.access_token, res.data.nickname)
+        } else {
+          alert('로그인 실패')
+          navigate('/login')
+        }
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  const login = async (accessToken: string, nickname: string) => {
+    try {
+      await loginApi(accessToken, nickname).then((res: LoginProps) => {
+        if (res.status === 200) {
+          localStorage.setItem('accessToken', res.data.accessToken)
+          localStorage.setItem('nickname', res.data.nickname)
+          localStorage.setItem('email', res.data.email)
+          localStorage.setItem('refreshToken', res.data.refreshToken)
+
+          navigate('/')
+        } else {
+          alert('로그인 실패')
+          navigate('/login')
+        }
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  useEffect(() => {
+    if (code) {
+      getKakaoUserInfo(code)
+    }
+  }, [code])
+
+  return (
+    <RedirectionOuterComponent>
+      <LoadingLoginImg src={loading} alt="loading" />
+      <LoadingLoginText>Loading..</LoadingLoginText>
+    </RedirectionOuterComponent>
+  )
+}
+
+export default KakaoRedirection
+
+const RedirectionOuterComponent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const LoadingLoginImg = styled.img`
+  width: 36px;
+  height: 36px;
+  margin: 300px 0px 0px 0px;
+`
+
+const LoadingLoginText = styled.div`
+  font-size: 20px;
+  font-weight: 600;
+  margin: 18px 0px 0px 0px;
+`

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 const Landing = () => {
-  return <LandingOuterComponent>랜딩페이지</LandingOuterComponent>
+  return <LandingOuterComponent>랜딩</LandingOuterComponent>
 }
 
 export default Landing

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components'
+
+const Login = () => {
+  return (
+    <LoginOuterComponent>
+      <KakaoLoginBtn>카카오 로그인</KakaoLoginBtn>
+    </LoginOuterComponent>
+  )
+}
+
+export default Login
+
+const LoginOuterComponent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const KakaoLoginBtn = styled.button`
+  background-color: yellow;
+  color: #000;
+  width: 200px;
+  height: 30px;
+  border: none;
+  cursor: pointer;
+`

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,17 @@
 import styled from 'styled-components'
 
 const Login = () => {
+  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID
+  const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI
+  const link = `http://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`
+
+  const loginHandler = () => {
+    window.location.href = link
+  }
+
   return (
     <LoginOuterComponent>
-      <KakaoLoginBtn>카카오 로그인</KakaoLoginBtn>
+      <KakaoLoginBtn onClick={loginHandler}>카카오 로그인</KakaoLoginBtn>
     </LoginOuterComponent>
   )
 }

--- a/src/pages/Outer.tsx
+++ b/src/pages/Outer.tsx
@@ -23,6 +23,9 @@ const TotalBrowserComponent = styled.div`
 const PhoneBrowserComponent = styled.div`
   width: 375px;
   min-height: 100%;
-  /* 경계 지을려고 일단 이렇게 설정함 추후 수정 예정 */
+  /* 경계 지을려고 일단 이렇게 설정함 추후 삭제 예정 */
   border: 1px solid black;
+  @media screen and (max-width<768px) {
+    width: 100%;
+  }
 `


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #[이슈번호]6

## 📝 작업 내용

- [x] 카카오 로그인 구현 완료
- [x] apis 폴더안에 api들 따로 저장하기
- [x] 받은 유저정보 localStorage에 저장하기
- [x] 768px이상일 때 375px, 이하일때 너비 100%로 변경 

## 테스트 결과 (스크린샷)
<img width="330" alt="스크린샷 2024-04-28 오후 5 31 36" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/c75f0d90-cc36-4d12-8955-bc2a2e1f2201">
<img width="330" alt="스크린샷 2024-04-28 오후 5 34 00" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/eaa177b3-3bb2-48f9-86bb-8ef4a1d83755">

