### PR TITLE
Feat/#11 로그인 페이지 구현

### DIFF
--- a/src/apis/UserApi.tsx
+++ b/src/apis/UserApi.tsx
@@ -8,6 +8,15 @@ export const getKakaoUserInfoApi = (code: string) => {
   return axios.get(`http://${serverUrl}/oauth/kakao/callback?code=${code}&redirectUri=${redirectUri}`)
 }
 
+// 카카오 어세스토큰을 통하여 회원가입 여부 확인
+export const isExistingAccountApi = (accessToken: string) => {
+  return axios.get(`http://${serverUrl}/api/oauth/isExisting`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+}
+
 // 카카오 어세스토큰을 통하여 jwt토큰 받기
 export const loginApi = (accessToken: string, nickname: string) => {
   return axios.post(

--- a/src/pages/KakaoRedirection.tsx
+++ b/src/pages/KakaoRedirection.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import { useEffect } from 'react'
-import { getKakaoUserInfoApi, loginApi } from '../apis/UserApi'
+import { getKakaoUserInfoApi, isExistingAccountApi, loginApi } from '../apis/UserApi'
 import loading from '../assets/kakaoRedirection/Loading.svg'
 
 const KakaoRedirection = () => {
@@ -23,11 +23,65 @@ const KakaoRedirection = () => {
     try {
       await getKakaoUserInfoApi(code).then((res: KakaoUserInfoResponseProps) => {
         if (res.status === 200) {
+          isExistingAccount(res.data.access_token)
+        } else {
+          alert('로그인 실패')
+          navigate('/login')
+        }
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  // GetKakaoUserInfo함수의 response 인터페이스
+  interface isExistingAccountResponseProps {
+    data: any
+    status: number
+    statusText: string
+    headers: any
+    config: any
+  }
+
+  // 이미 존재하는 회원인지 여부 확인(여기 accessToken은 카카오어세스토큰)
+  const isExistingAccount = async (accessToken: string) => {
+    try {
+      await isExistingAccountApi(accessToken).then((res: isExistingAccountResponseProps) => {
+        if (res.data.isExisting) {
+          login(accessToken, 'null')
+        } else {
           navigate('/signup', {
             state: {
-              kakaoAccessToken: res.data.access_token,
+              kakaoAccessToken: accessToken,
             },
           })
+        }
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  // Login함수의 response 인터페이스
+  interface LoginProps {
+    data: any
+    status: number
+    statusText: string
+    headers: any
+    config: any
+  }
+
+  // 이미 존재하는 회원일 경우 바로 로그인 진행
+  const login = async (kakaoAccessToken: string, nickname: string) => {
+    try {
+      await loginApi(kakaoAccessToken, nickname).then((res: LoginProps) => {
+        if (res.status === 200) {
+          localStorage.setItem('accessToken', res.data.accessToken)
+          localStorage.setItem('nickname', res.data.nickname)
+          localStorage.setItem('email', res.data.email)
+          localStorage.setItem('refreshToken', res.data.refreshToken)
+
+          navigate('/')
         } else {
           alert('로그인 실패')
           navigate('/login')

--- a/src/pages/KakaoRedirection.tsx
+++ b/src/pages/KakaoRedirection.tsx
@@ -18,41 +18,16 @@ const KakaoRedirection = () => {
     config: any
   }
 
-  // Login함수의 response 인터페이스
-  interface LoginProps {
-    data: any
-    status: number
-    statusText: string
-    headers: any
-    config: any
-  }
-
   // 카카오에서 유저정보 받아오기
   const getKakaoUserInfo = async (code: string) => {
     try {
       await getKakaoUserInfoApi(code).then((res: KakaoUserInfoResponseProps) => {
         if (res.status === 200) {
-          login(res.data.access_token, res.data.nickname)
-        } else {
-          alert('로그인 실패')
-          navigate('/login')
-        }
-      })
-    } catch (err) {
-      console.log(err)
-    }
-  }
-
-  const login = async (accessToken: string, nickname: string) => {
-    try {
-      await loginApi(accessToken, nickname).then((res: LoginProps) => {
-        if (res.status === 200) {
-          localStorage.setItem('accessToken', res.data.accessToken)
-          localStorage.setItem('nickname', res.data.nickname)
-          localStorage.setItem('email', res.data.email)
-          localStorage.setItem('refreshToken', res.data.refreshToken)
-
-          navigate('/')
+          navigate('/signup', {
+            state: {
+              kakaoAccessToken: res.data.access_token,
+            },
+          })
         } else {
           alert('로그인 실패')
           navigate('/login')

--- a/src/pages/KakaoRedirection.tsx
+++ b/src/pages/KakaoRedirection.tsx
@@ -45,16 +45,16 @@ const KakaoRedirection = () => {
   }, [code])
 
   return (
-    <RedirectionOuterComponent>
+    <Container>
       <LoadingLoginImg src={loading} alt="loading" />
       <LoadingLoginText>Loading..</LoadingLoginText>
-    </RedirectionOuterComponent>
+    </Container>
   )
 }
 
 export default KakaoRedirection
 
-const RedirectionOuterComponent = styled.div`
+const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
 
 const Landing = () => {
-  return <LandingOuterComponent>랜딩페이지</LandingOuterComponent>
+  return <Container>랜딩페이지</Container>
 }
 
 export default Landing
 
-const LandingOuterComponent = styled.div`
-  font-family: 'Pretendard';
+const Container = styled.div`
+  font-family: Pretendard;
 `

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -10,16 +10,16 @@ const Login = () => {
   }
 
   return (
-    <LoginOuterComponent>
+    <Container>
       <FlipItIcon>로고</FlipItIcon>
       <KakaoLoginBtn onClick={loginHandler}>카카오 로그인</KakaoLoginBtn>
-    </LoginOuterComponent>
+    </Container>
   )
 }
 
 export default Login
 
-const LoginOuterComponent = styled.div`
+const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/pages/Outer.tsx
+++ b/src/pages/Outer.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { Outlet } from 'react-router-dom'
-
+import { colors } from '../styles/colors'
 const Outer = () => {
   return (
     <TotalBrowserContainer>
@@ -16,14 +16,14 @@ export default Outer
 const TotalBrowserContainer = styled.div`
   display: flex;
   justify-content: center;
-  background-color: #fff;
+  background-color: ${colors.white};
   width: 100vw;
   min-height: 100vh;
 `
 
 const PhoneBrowserContainer = styled.div`
   width: 375px;
-  background-color: #f5f5f5;
+  background-color: ${colors.grey7};
   min-height: 100%;
   @media screen and (max-width: 768px) {
     width: 100%;

--- a/src/pages/Outer.tsx
+++ b/src/pages/Outer.tsx
@@ -3,17 +3,17 @@ import { Outlet } from 'react-router-dom'
 
 const Outer = () => {
   return (
-    <TotalBrowserComponent>
-      <PhoneBrowserComponent>
+    <TotalBrowserContainer>
+      <PhoneBrowserContainer>
         <Outlet />
-      </PhoneBrowserComponent>
-    </TotalBrowserComponent>
+      </PhoneBrowserContainer>
+    </TotalBrowserContainer>
   )
 }
 
 export default Outer
 
-const TotalBrowserComponent = styled.div`
+const TotalBrowserContainer = styled.div`
   display: flex;
   justify-content: center;
   background-color: #fff;
@@ -21,7 +21,7 @@ const TotalBrowserComponent = styled.div`
   min-height: 100vh;
 `
 
-const PhoneBrowserComponent = styled.div`
+const PhoneBrowserContainer = styled.div`
   width: 375px;
   background-color: #f5f5f5;
   min-height: 100%;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -47,7 +47,7 @@ const SignUp = () => {
   }
 
   return (
-    <SignUpTotalComponent>
+    <Container>
       <Header text="텍스트" backColor={colors.white} />
       <SignUpHeaderText>
         플리빗을 사용하기 위해 <br />
@@ -55,34 +55,42 @@ const SignUp = () => {
       </SignUpHeaderText>
       <SignUpNicknameLabel>닉네임</SignUpNicknameLabel>
       <SingUpNicknameInput value={nickname} onChange={onChangeNickname} placeholder="닉네임 입력" />
-      <NextBtn>다음</NextBtn>
-    </SignUpTotalComponent>
+      {nickname !== '' ? (
+        <NextBtn
+          onClick={() => {
+            login(kakaoAccessToken, nickname)
+          }}
+          positive={true}
+        >
+          다음
+        </NextBtn>
+      ) : (
+        <NextBtn positive={false}>다음</NextBtn>
+      )}
+    </Container>
   )
 }
 
 export default SignUp
 
-const SignUpTotalComponent = styled.div`
+const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
 `
 
 const SignUpHeaderText = styled.div`
   font-family: Pretendard;
-  width: 335px;
   height: 54px;
   color: #1d1d1d;
   font-size: 18px;
   font-weight: 600;
-  margin: 20px 0px 0px 0px;
+  margin: 20px 20px 0px 20px;
 `
 
 const SignUpNicknameLabel = styled.div`
   font-family: Pretendard;
-  color: #767676;
-  align-self: flex-start;
+  color: ${colors.grey3};
   font-size: 12px;
   font-weight: 400;
   margin: 40px 0px 0px 20px;
@@ -111,23 +119,25 @@ const SingUpNicknameInput = styled.input`
   }
 `
 
-const NextBtn = styled.button`
-  font-family: Pretendard;
+const NextBtn = styled.button<{ positive: boolean }>`
   position: absolute;
   bottom: 30px;
-  border: none;
-  width: 335px;
+  left: 20px;
+  right: 20px;
+  width: calc(100%-40px);
+  display: flex;
   height: 56px;
+  padding: 16px 20px;
+  justify-content: center;
+  align-items: center;
   border-radius: 12px;
-  background-color: #55eab0;
-  color: #1d1d1d;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--Grayscale-Gray-03, #767676);
+  background: ${(props) => (props.positive ? colors.primary : colors.primary40)};
+  color: ${(props) => (props.positive ? colors.grey1 : colors.grey3)};
   font-family: Pretendard;
   font-size: 14px;
   font-style: normal;
   font-weight: 600;
-  line-height: 150%; /* 21px */
+  line-height: 150%;
   letter-spacing: -0.28px;
+  border: none;
 `

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -19,6 +19,7 @@ const SignUp = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const kakaoAccessToken = location.state?.kakaoAccessToken
+
   const [nickname, setNickname] = useState<string>('')
 
   const onChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -83,7 +83,7 @@ const Container = styled.div`
 const SignUpHeaderText = styled.div`
   font-family: Pretendard;
   height: 54px;
-  color: #1d1d1d;
+  color: ${colors.grey1};
   font-size: 18px;
   font-weight: 600;
   margin: 20px 20px 0px 20px;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,34 +1,60 @@
 import styled from 'styled-components'
 import Header from '../components/common/Header'
-import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+import { loginApi } from '../apis/UserApi'
 import { colors } from '../styles/colors'
+import { ChangeEvent, useState } from 'react'
 
+// Login함수의 response 인터페이스
+interface LoginProps {
+  data: any
+  status: number
+  statusText: string
+  headers: any
+  config: any
+}
 
 const SignUp = () => {
-  //   const divRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+  const location = useLocation()
+  const kakaoAccessToken = location.state?.kakaoAccessToken
+  const [nickname, setNickname] = useState<string>('')
 
-  //   useEffect(() => {
-  //     const handleVisualViewPortResize = () => {
-  //       const currentVisualViewport = Number(window.visualViewport?.height)
-  //       if (divRef) {
-  //         divRef.current!.style.height = `${currentVisualViewport - 30}px`
-  //         window.scrollTo(0, 40)
-  //       }
-  //       if (window.visualViewport) {
-  //         window.visualViewport.onresize = handleVisualViewPortResize
-  //       }
-  //     }
-  //   }, [])
+  const onChangeNickname = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setNickname(value)
+  }
+
+  const login = async (kakaoAccessToken: string, nickname: string) => {
+    try {
+      await loginApi(kakaoAccessToken, nickname).then((res: LoginProps) => {
+        if (res.status === 200) {
+          localStorage.setItem('accessToken', res.data.accessToken)
+          localStorage.setItem('nickname', res.data.nickname)
+          localStorage.setItem('email', res.data.email)
+          localStorage.setItem('refreshToken', res.data.refreshToken)
+
+          navigate('/')
+        } else {
+          alert('로그인 실패')
+          navigate('/login')
+        }
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
 
   return (
     <SignUpTotalComponent>
-      <Header text="텍스트" backColor={colors.grey7} />
+      <Header text="텍스트" backColor={colors.white} />
       <SignUpHeaderText>
         플리빗을 사용하기 위해 <br />
         닉네임이 필요해요!
       </SignUpHeaderText>
       <SignUpNicknameLabel>닉네임</SignUpNicknameLabel>
-      <SingUpNicknameInput placeholder="닉네임 입력" />
+      <SingUpNicknameInput value={nickname} onChange={onChangeNickname} placeholder="닉네임 입력" />
       <NextBtn>다음</NextBtn>
     </SignUpTotalComponent>
   )
@@ -41,11 +67,10 @@ const SignUpTotalComponent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: calc(100vh - 48px);
 `
 
 const SignUpHeaderText = styled.div`
-  font-family: 'Pretendard';
+  font-family: Pretendard;
   width: 335px;
   height: 54px;
   color: #1d1d1d;
@@ -55,7 +80,7 @@ const SignUpHeaderText = styled.div`
 `
 
 const SignUpNicknameLabel = styled.div`
-  font-family: 'Pretendard';
+  font-family: Pretendard;
   color: #767676;
   align-self: flex-start;
   font-size: 12px;
@@ -64,27 +89,30 @@ const SignUpNicknameLabel = styled.div`
 `
 
 const SingUpNicknameInput = styled.input`
-  font-family: 'Pretendard';
-  width: 335px;
-  height: 61px;
   padding: 20px;
+  margin: 4px 20px;
   border-radius: 12px;
-  background-color: #fff;
-  color: #1d1d1d;
+  background: ${colors.white};
+  align-self: stretch;
+  color: ${colors.grey1};
+  font-family: Pretendard;
   font-size: 14px;
-  margin: 4px 0px 0px 0px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%;
+  letter-spacing: -0.56px;
   border: none;
-  outline: none;
-  &:hover {
-    border: 1px solid #1d1d1d;
+  &:focus {
+    outline: none;
+    border: 1px solid ${colors.grey1};
   }
   &::placeholder {
-    color: #c1c1c1;
+    color: ${colors.grey5};
   }
 `
 
 const NextBtn = styled.button`
-  font-family: 'Pretendard';
+  font-family: Pretendard;
   position: absolute;
   bottom: 30px;
   border: none;
@@ -95,5 +123,11 @@ const NextBtn = styled.button`
   color: #1d1d1d;
   font-size: 14px;
   font-weight: 600;
-  /* margin: 300px 0px 0px 0px; */
+  color: var(--Grayscale-Gray-03, #767676);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 150%; /* 21px */
+  letter-spacing: -0.28px;
 `


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #[이슈번호]11

## 📝 작업 내용

- [x] 닉네임 입력 페이지 구현
- [x] 온보딩 페이지 전체적인 css 수정
- [x] 받은 카카오 로그인으로 이미 회원가입한 계정인지 여부 확인
        이미 회원가입한 계정 -> 로그인 후 랜딩페이지 이동
        회원가입하지 않은 계정 -> 닉네임 입력 페이지로 이동

## 테스트 결과 (스크린샷)
<img width="339" alt="스크린샷 2024-05-02 오후 8 25 53" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/16308ed2-2aa1-4f26-a7be-a36d721da4df">
<img width="339" alt="스크린샷 2024-05-02 오후 8 26 44" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/c2fbc54b-75e7-415e-bab1-8c93ff2781d4">
<img width="339" alt="스크린샷 2024-05-02 오후 8 27 09" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/4a5eac21-b7d9-4dbf-bc3d-9627cf4df851">
<img width="339" alt="스크린샷 2024-05-02 오후 8 27 41" src="https://github.com/Team-baebae/baebae-FE/assets/102502542/aba9861b-a70e-453e-916e-cb880af317db">
