### PR TITLE
Feat/#25 카테고리 생성,수정,삭제,조회 api 연동

### DIFF
--- a/src/apis/DirectoryApi.tsx
+++ b/src/apis/DirectoryApi.tsx
@@ -47,10 +47,14 @@ export const deleteDirectoryApi = (accessToken: string, categoryId: number) => {
   })
 }
 
-export const modifyDirectoryApi = (accessToken: string, categoryId: number) => {
+export const modifyDirectoryApi = (accessToken: string, categoryId: number, categoryName: string, answerIds: any) => {
   return axios.put(
     `http://${serverUrl}/api/category/${categoryId}`,
-    {},
+    {
+      categoryId: categoryId,
+      categoryName: categoryName,
+      answerIds: answerIds,
+    },
     {
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/src/apis/DirectoryApi.tsx
+++ b/src/apis/DirectoryApi.tsx
@@ -1,3 +1,74 @@
 import axios from 'axios'
 
 const serverUrl = import.meta.env.VITE_SERVER_URL
+
+export const getDirectoriesApi = (accessToken: string, memberId: number) => {
+  return axios.get(`http://${serverUrl}/api/category/${memberId}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+}
+
+export const makeDirectoryApi = (
+  accessToken: string,
+  memberId: number,
+  categoryImage: File | undefined,
+  categoryName: string,
+  answerIds: any,
+) => {
+  // FormData 객체 생성
+  const formData = new FormData()
+  // categoryImage가 undefined가 아니면 FormData에 추가
+  if (categoryImage) {
+    formData.append('categoryImage', categoryImage)
+  } else {
+    console.warn('No category image provided')
+  }
+  const createCategory = {
+    categoryName: categoryName,
+    answerIds: answerIds,
+  }
+  formData.append('createCategory', JSON.stringify(createCategory))
+
+  return axios.post(`http://${serverUrl}/api/category/${memberId}`, formData, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'multipart/form-data', // 컨텐츠 타입을 multipart/form-data로 지정
+    },
+  })
+}
+
+export const deleteDirectoryApi = (accessToken: string, categoryId: number) => {
+  return axios.delete(`http://${serverUrl}/api/category/${categoryId}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+}
+
+export const modifyDirectoryApi = (accessToken: string, categoryId: number) => {
+  return axios.put(
+    `http://${serverUrl}/api/category/${categoryId}`,
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  )
+}
+
+export const updateDirectoryImgApi = (accessToken: string, categoryId: number, imageFile: File) => {
+  return axios.patch(
+    `http://${serverUrl}/api/category/${categoryId}/image`,
+    {
+      imageFile: imageFile,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  )
+}

--- a/src/components/folder/Feeds.tsx
+++ b/src/components/folder/Feeds.tsx
@@ -26,7 +26,6 @@ const Feeds = ({ data }: FeedsProps) => {
           </FlipWrapper>
         ))}
       </GridContainer>
-      <TotalFeedsBtn>전체 보기</TotalFeedsBtn>
     </>
   )
 }

--- a/src/components/main/Feed.tsx
+++ b/src/components/main/Feed.tsx
@@ -13,7 +13,7 @@ import { BottomSheet } from 'react-spring-bottom-sheet'
 import 'react-spring-bottom-sheet/dist/style.css'
 import pencil from '../../assets/feed/Pencil.svg'
 import trash from '../../assets/feed/Trash.svg'
-import { getDirectoriesApi } from '../../apis/DirectoryApi'
+import { deleteDirectoryApi, getDirectoriesApi } from '../../apis/DirectoryApi'
 import { useRecoilState } from 'recoil'
 import { userInfoState } from '../../context/Atoms'
 import { useNavigate } from 'react-router-dom'
@@ -75,7 +75,7 @@ const Feed = () => {
     },
   ]
 
-  const [selectedDirectoryId, setSelectedDirectoryId] = useState<number | null>(null) // 선택된 디렉토리 ID 상태
+  const [selectedDirectoryId, setSelectedDirectoryId] = useState<number>(0) // 선택된 디렉토리 ID 상태
   const holdTimer = useRef<number | null>(null) // useRef에 타입 명시
 
   // open은 모달 열고 닫는 상태
@@ -110,6 +110,17 @@ const Feed = () => {
       }
     },
   })
+
+  const deleteDirectory = async () => {
+    try {
+      await deleteDirectoryApi(userInfo.accessToken, selectedDirectoryId).then((res) => {
+        setOpen(false)
+        getDirectories()
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
 
   useEffect(() => {
     getDirectories()
@@ -165,7 +176,9 @@ const Feed = () => {
           </BottomSheetEachWrapper>
           <BottomSheetEachWrapper>
             <BottomSheetEachIcon src={trash} />
-            <BottomSheetEachText color="#f00">그룹 삭제하기</BottomSheetEachText>
+            <BottomSheetEachText onClick={deleteDirectory} color="#f00">
+              그룹 삭제하기
+            </BottomSheetEachText>
           </BottomSheetEachWrapper>
         </BottomSheet>
       )}

--- a/src/components/main/Feed.tsx
+++ b/src/components/main/Feed.tsx
@@ -13,53 +13,34 @@ import { BottomSheet } from 'react-spring-bottom-sheet'
 import 'react-spring-bottom-sheet/dist/style.css'
 import pencil from '../../assets/feed/Pencil.svg'
 import trash from '../../assets/feed/Trash.svg'
+import { getDirectoriesApi } from '../../apis/DirectoryApi'
+import { useRecoilState } from 'recoil'
+import { userInfoState } from '../../context/Atoms'
+import { useNavigate } from 'react-router-dom'
 
 const Feed = () => {
-  const groups = [
-    {
-      directoryId: 1,
-      directoryName: '영화',
-      directoryImg: logo,
-    },
-    {
-      directoryId: 2,
+  const navigate = useNavigate()
 
-      directoryName: '음식',
-      directoryImg: logo,
-    },
-    {
-      directoryId: 3,
+  const [userInfo, setUserInfo] = useRecoilState(userInfoState)
 
-      directoryName: '노래',
-      directoryImg: logo,
-    },
-    {
-      directoryId: 4,
+  const getDirectories = async () => {
+    try {
+      await getDirectoriesApi(userInfo.accessToken, userInfo.memberId).then((res) => {
+        setDirectories(res.data.categories)
+      })
+    } catch (err) {
+      console.log(err)
+    }
+  }
 
-      directoryName: '폴더',
-      directoryImg: logo,
-    },
-    {
-      directoryId: 5,
+  interface directory {
+    categoryId: number
+    categoryName: string
+    answerAnswers: number[]
+    categoryImage: string
+  }
 
-      directoryName: '폴더',
-      directoryImg: logo,
-    },
-    {
-      directoryId: 6,
-
-      directoryName: '폴더',
-      directoryImg: logo,
-    },
-    {
-      directoryName: '폴더',
-      directoryImg: logo,
-    },
-    {
-      directoryName: '폴더',
-      directoryImg: logo,
-    },
-  ]
+  const [directories, setDirectories] = useState<directory[]>([])
 
   const feedList = [
     {
@@ -130,6 +111,10 @@ const Feed = () => {
     },
   })
 
+  useEffect(() => {
+    getDirectories()
+  }, [])
+
   return (
     <Container>
       <TopComponent>
@@ -139,20 +124,20 @@ const Feed = () => {
           onSwiper={(swiper) => console.log(swiper)}
           onSlideChange={() => console.log('slide change')}
         >
-          {groups.map((item) => {
+          {directories.map((item) => {
             return (
-              <SwiperSlide key={item.directoryId}>
+              <SwiperSlide key={item.categoryId}>
                 <GroupWrapper>
                   <GroupImgWrapper
-                    {...bind(item.directoryId)}
+                    {...bind(item.categoryId)}
                     onContextMenu={(e) => {
                       e.preventDefault()
                       e.stopPropagation()
                     }}
                   >
-                    <GroupImg src={item.directoryImg} />
+                    <GroupImg src={item.categoryImage} />
                   </GroupImgWrapper>
-                  <GroupName>{item.directoryName}</GroupName>
+                  <GroupName>{item.categoryName}</GroupName>
                 </GroupWrapper>
               </SwiperSlide>
             )
@@ -160,7 +145,12 @@ const Feed = () => {
 
           <SwiperSlide>
             <GroupWrapper>
-              <GroupPlusImg src={plus} />
+              <GroupPlusImg
+                onClick={() => {
+                  navigate('/groupPlus')
+                }}
+                src={plus}
+              />
               <GroupName>추가</GroupName>
             </GroupWrapper>
           </SwiperSlide>

--- a/src/components/main/Feed.tsx
+++ b/src/components/main/Feed.tsx
@@ -122,6 +122,14 @@ const Feed = () => {
     }
   }
 
+  const moveModifyDirectory = () => {
+    navigate('/groupModify', {
+      state: {
+        categoryId: selectedDirectoryId,
+      },
+    })
+  }
+
   useEffect(() => {
     getDirectories()
   }, [])
@@ -170,15 +178,13 @@ const Feed = () => {
       {feedList.length > 0 ? <Feeds data={feedList} /> : <Flips />}
       {open && (
         <BottomSheet open={open} snapPoints={() => [170]} onDismiss={handleDismissPlusMusicModal} blocking={true}>
-          <BottomSheetEachWrapper>
+          <BottomSheetEachWrapper onClick={moveModifyDirectory}>
             <BottomSheetEachIcon src={pencil} />
             <BottomSheetEachText color={colors.grey1}>그룹 수정하기</BottomSheetEachText>
           </BottomSheetEachWrapper>
-          <BottomSheetEachWrapper>
+          <BottomSheetEachWrapper onClick={deleteDirectory}>
             <BottomSheetEachIcon src={trash} />
-            <BottomSheetEachText onClick={deleteDirectory} color="#f00">
-              그룹 삭제하기
-            </BottomSheetEachText>
+            <BottomSheetEachText color="#f00">그룹 삭제하기</BottomSheetEachText>
           </BottomSheetEachWrapper>
         </BottomSheet>
       )}

--- a/src/pages/GroupPlus.tsx
+++ b/src/pages/GroupPlus.tsx
@@ -4,14 +4,35 @@ import { colors } from '../styles/colors'
 import { useState } from 'react'
 import Feeds from '../components/folder/Feeds'
 import Flips from '../components/main/Flips'
+import { makeDirectoryApi, updateDirectoryImgApi } from '../apis/DirectoryApi'
+import { useRecoilState } from 'recoil'
+import { userInfoState } from '../context/Atoms'
+import { UnFixedButton } from '../components/common/Button'
+import { useNavigate } from 'react-router-dom'
 
 const GroupPlus = () => {
-  const [folderImgUrl, setFolderImgUrl] = useState<string>('')
-  const [folderName, setFolderName] = useState<string>('')
+  const navigate = useNavigate()
+
+  const [userInfo, setUserInfo] = useRecoilState(userInfoState)
+
+  const [directoryImgUrl, setDirectoryImgUrl] = useState<string>('')
+  const [directoryImgFile, setDirectoryImgFile] = useState<File>()
+  const [answerIds, setAnswerIds] = useState<any>([])
+  // 이미지 파일 선택 핸들러
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0]
+    // 이미지 파일을 보낼 시엔 formData로 file을 추가해야함(추후 추가)
+    if (file) {
+      setDirectoryImgFile(file)
+      setDirectoryImgUrl(URL.createObjectURL(file)) // 미리보기를 위해 파일 URL 생성
+    }
+  }
+
+  const [categoryName, setCategoryName] = useState<string>('')
 
   const onChangeFolderName = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
-    setFolderName(value)
+    setCategoryName(value)
   }
 
   const feedList = [
@@ -47,27 +68,43 @@ const GroupPlus = () => {
     },
   ]
 
+  const makeDirectory = async () => {
+    try {
+      await makeDirectoryApi(userInfo.accessToken, userInfo.memberId, directoryImgFile, categoryName, answerIds).then(
+        (res) => {
+          console.log(res)
+          navigate(`/${userInfo.nickname}`)
+        },
+      )
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
   return (
     <Container>
       <GroupHeader text="새 그룹 추가" background={colors.grey7} />
       <FolderImgWrapper>
         <FolderImg />
       </FolderImgWrapper>
-      <EditFolderImgText>사진 수정하기</EditFolderImgText>
+      <label htmlFor="file">
+        <EditFolderImgText>사진 수정하기</EditFolderImgText>
+      </label>
+      <input type="file" name="file" id="file" style={{ display: 'none' }} onChange={handleImageChange} />
       <FolderNameLabel>그룹명</FolderNameLabel>
-      <FolderName value={folderName} onChange={onChangeFolderName} placeholder="그룹명을 입력해주세요" />
+      <FolderName value={categoryName} onChange={onChangeFolderName} placeholder="그룹명을 입력해주세요" />
       <FolderNameConditionWrapper>
         <FolderNameConditionText color={colors.grey1} fontSize="12px">
           2-8자로 입력해주세요.
         </FolderNameConditionText>
         <FolderNameLengthWrapper>
-          {folderName.length > 0 ? (
+          {categoryName.length > 0 ? (
             <FolderNameConditionText color={colors.grey2} fontSize="10px">
-              {folderName.length}
+              {categoryName.length}
             </FolderNameConditionText>
           ) : (
             <FolderNameConditionText color={colors.grey4} fontSize="10px">
-              {folderName.length}
+              {categoryName.length}
             </FolderNameConditionText>
           )}
 
@@ -83,6 +120,13 @@ const GroupPlus = () => {
         추가할 플립 선택
       </FolderNameConditionText>
       {feedList.length > 0 ? <Feeds data={feedList} /> : <Flips />}
+      <UnFixedButton
+        $positive={true}
+        func={makeDirectory}
+        func2={() => console.log('실패')}
+        text="그룹 추가하기"
+        margin="30px 20px 30px 20px"
+      />
     </Container>
   )
 }

--- a/src/pages/KakaoRedirection.tsx
+++ b/src/pages/KakaoRedirection.tsx
@@ -84,6 +84,7 @@ const KakaoRedirection = () => {
       await loginApi(kakaoAccessToken, nickname).then((res: LoginProps) => {
         if (res.status === 200) {
           console.log(res.data.accessToken)
+          console.log(res.data.id)
           setUserInfo({
             ...userInfo,
             memberId: res.data.id,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #[이슈번호]25

## 📝 작업 내용

- [x] 카테고리 생성 api 연동 (피드 선택 제외)
- [x] 카테고리 조회 api 연동
- [x] 카테고리 삭제 api 연동
- [x] 카테고리 수정 api 연동 (피드 선택 제외)

## 테스트 결과 (스크린샷)
